### PR TITLE
Fix deploy script

### DIFF
--- a/deploy/docker-compose/deploy.sh
+++ b/deploy/docker-compose/deploy.sh
@@ -22,5 +22,5 @@ SCYTALE_VERSION=${SCYTALE_VERSION:-0.1.5} \
 PETASOS_VERSION=${PETASOS_VERSION:-0.1.4} \
 TALARIA_VERSION=${TALARIA_VERSION:-0.1.3} \
 SIMULATOR_VERSION=${SIMULATOR_VERSION:-local} \
-docker-compose -f deploy/docker-compose/docker-compose.yml up -d $@
+docker-compose -f $ROOT_DIR/deploy/docker-compose/docker-compose.yml up -d $@
 


### PR DESCRIPTION
After working on https://github.com/xmidt-org/codex-deploy/pull/104, I realized I missed something.

This change ensures that the docker-compose command on the script can be run on any working directory. 