### PR TITLE
fixing consul address

### DIFF
--- a/deploy/docker-compose/docFiles/talaria-2.yaml
+++ b/deploy/docker-compose/docFiles/talaria-2.yaml
@@ -85,7 +85,7 @@
     defaultScheme: http
     consul:
       client:
-        address: "consul1:8500"
+        address: "consul0:8500"
         scheme: "http"
         waitTime: "30s"
       disableGenerateID: true


### PR DESCRIPTION
I'm not sure if this was intentionally set to a different addres to demonstrate multi-datacenter? but Changing this to consul0 causes all Talaria to appear in Consul:

![image](https://user-images.githubusercontent.com/10401881/81854706-2f609f00-9513-11ea-8bec-604c021ec28c.png)
