### PR TITLE
Copy real libs instead of symlinks from parodus build

### DIFF
--- a/simulator/Dockerfile
+++ b/simulator/Dockerfile
@@ -35,24 +35,27 @@ COPY --from=packager /build/parodus2mockTr181/etc/mock_tr181.json /etc/mock_tr18
 COPY --from=packager /build/parodus2mockTr181/build/_install/lib/libwdmp-c.so /usr/lib/
 COPY --from=packager /build/parodus2mockTr181/build/_install/lib/liblibparodus.so /usr/lib/
 COPY --from=packager /build/parodus/build/src/parodus /usr/bin/
-COPY --from=packager /build/parodus/build/_install/lib/libcimplog.so /usr/lib/
-COPY --from=packager /build/parodus/build/_install/lib64/libcjson.so /usr/lib/
+COPY --from=packager /build/parodus/build/_install/lib/libcimplog.so.1.0.0 /usr/lib/
+COPY --from=packager /build/parodus/build/_install/lib64/libcjson.so.1.7.8 /usr/lib/
 COPY --from=packager /build/parodus/build/_install/lib/libcjwt.so /usr/lib/
-COPY --from=packager /build/parodus/build/_install/lib/libmsgpackc.so /usr/lib/
-COPY --from=packager /build/parodus/build/_install/lib/libnopoll.so /usr/lib/
-COPY --from=packager /build/parodus/build/_install/lib/libtrower-base64.so /usr/lib/
+COPY --from=packager /build/parodus/build/_install/lib/libmsgpackc.so.2.0.0 /usr/lib/
+COPY --from=packager /build/parodus/build/_install/lib/libnopoll.so.0.0.0 /usr/lib/
+COPY --from=packager /build/parodus/build/_install/lib/libtrower-base64.so.1.0.0 /usr/lib/
 COPY --from=packager /build/parodus/build/_install/lib/libwrp-c.so /usr/lib/
-COPY --from=packager /build/parodus/build/_install/lib64/libnanomsg.so /usr/lib/
+COPY --from=packager /build/parodus/build/_install/lib64/libnanomsg.so.5.1.0 /usr/lib/
 COPY --from=packager /build/parodus/build/_install/lib64/libcurl.so /usr/lib/
 COPY ./simulate /usr/bin/simulate
 RUN chmod uga+x /usr/bin/simulate && \
     apk add --no-cache openssl libuuid && \
-    cp /usr/lib/libcurl.so /usr/lib/libcurl.so.1 && \
-    cp /usr/lib/libmsgpackc.so /usr/lib/libmsgpackc.so.2 && \
-    cp /usr/lib/libtrower-base64.so /usr/lib/libtrower-base64.so.1.0.0 && \
-    cp /usr/lib/libnopoll.so /usr/lib/libnopoll.so.0 && \
-    cp /usr/lib/libcimplog.so /usr/lib/libcimplog.so.1.0.0 && \
-    cp /usr/lib/libnanomsg.so /usr/lib/libnanomsg.so.5 && \
-    cp /usr/lib/libnanomsg.so /usr/lib/libnanomsg.so.5.1.0 && \
-    cp /usr/lib/libcjson.so /usr/lib/libcjson.so.1
+    ln -s /usr/lib/libcurl.so /usr/lib/libcurl.so.1 && \
+    ln -s /usr/lib/libmsgpackc.so.2.0.0 /usr/lib/libmsgpackc.so && \
+    ln -s /usr/lib/libmsgpackc.so.2.0.0 /usr/lib/libmsgpackc.so.2 && \
+    ln -s /usr/lib/libtrower-base64.so.1.0.0 /usr/lib/libtrower-base64.so && \
+    ln -s /usr/lib/libnopoll.so.0.0.0 /usr/lib/libnopoll.so && \
+    ln -s /usr/lib/libnopoll.so.0.0.0 /usr/lib/libnopoll.so.0 && \
+    ln -s /usr/lib/libcimplog.so.1.0.0 /usr/lib/libcimplog.so && \
+    ln -s /usr/lib/libnanomsg.so.5.1.0 /usr/lib/libnanomsg.so.5 && \
+    ln -s /usr/lib/libnanomsg.so.5 /usr/lib/libnanomsg.so && \
+    ln -s /usr/lib/libcjson.so.1.7.8 /usr/lib/libcjson.so.1 && \
+    ln -s /usr/lib/libcjson.so.1 /usr/lib/libcjson.so
 ENTRYPOINT [ "/usr/bin/simulate" ]

--- a/simulator/Dockerfile
+++ b/simulator/Dockerfile
@@ -14,6 +14,7 @@ RUN cd /build && \
     cd /build && \
     git clone https://github.com/Comcast/parodus.git && \
     cd parodus && \
+    git checkout ad2d43b4f6e980a6cc1c1340fc82564104eb1dd8 && \
     mkdir build && \
     cd build && \
     cmake .. && make && \

--- a/simulator/Dockerfile
+++ b/simulator/Dockerfile
@@ -47,13 +47,12 @@ COPY --from=packager /build/parodus/build/_install/lib64/libcurl.so /usr/lib/
 COPY ./simulate /usr/bin/simulate
 RUN chmod uga+x /usr/bin/simulate && \
     apk add --no-cache openssl libuuid && \
-    ln -s /usr/lib/libcurl.so /usr/lib/libcurl.so.1 && \
-    ln -s /usr/lib/libmsgpackc.so /usr/lib/libmsgpackc.so.2 && \
-    ln -s /usr/lib/libtrower-base64.so /usr/lib/libtrower-base64.so.1.0.0 && \
-    ln -s /usr/lib/libnopoll.so /usr/lib/libnopoll.so.0 && \
-    ln -s /usr/lib/libcimplog.so /usr/lib/libcimplog.so.1.0.0 && \
-    ln -s /usr/lib/libnanomsg.so /usr/lib/libnanomsg.so.5 && \
-    ln -s /usr/lib/libnanomsg.so /usr/lib/libnanomsg.so.5.1.0 && \
-    ln -s /usr/lib/libcjson.so /usr/lib/libcjson.so.1
-
+    cp /usr/lib/libcurl.so /usr/lib/libcurl.so.1 && \
+    cp /usr/lib/libmsgpackc.so /usr/lib/libmsgpackc.so.2 && \
+    cp /usr/lib/libtrower-base64.so /usr/lib/libtrower-base64.so.1.0.0 && \
+    cp /usr/lib/libnopoll.so /usr/lib/libnopoll.so.0 && \
+    cp /usr/lib/libcimplog.so /usr/lib/libcimplog.so.1.0.0 && \
+    cp /usr/lib/libnanomsg.so /usr/lib/libnanomsg.so.5 && \
+    cp /usr/lib/libnanomsg.so /usr/lib/libnanomsg.so.5.1.0 && \
+    cp /usr/lib/libcjson.so /usr/lib/libcjson.so.1
 ENTRYPOINT [ "/usr/bin/simulate" ]


### PR DESCRIPTION
We recently moved from a docker-in-docker build to a [kaniko](https://github.com/GoogleContainerTools/kaniko) base build. Kaniko didn't like the simulator build due to the symlink pointing to themselves. Not sure if this was intentionally? Maybe to keep the image size small?

This PR creates the necessary symlinks + copies the real librarys (not just symlinks) from the first build step. 

Here is a filesystem excerpt after the first build stage. 
There you can see that e.g. **libnopoll.so** is a symlink and not the lib itself.
```
/build/parodus/build/_install/lib
total 1672
drwxr-xr-x    4 root     root          4096 Sep 22 11:49 .
drwxr-xr-x    6 root     root          4096 Sep 22 11:48 ..
drwxr-xr-x    4 root     root          4096 Sep 22 11:49 cmake
-rw-r--r--    1 root     root          3984 Sep 22 11:46 libcimplog.a
lrwxrwxrwx    1 root     root            19 Sep 22 11:46 libcimplog.so -> libcimplog.so.1.0.0
-rwxr-xr-x    1 root     root          9448 Sep 22 11:46 libcimplog.so.1.0.0
-rw-r--r--    1 root     root         28726 Sep 22 11:48 libcjwt.a
-rwxr-xr-x    1 root     root         31312 Sep 22 11:48 libcjwt.so
lrwxrwxrwx    1 root     root            14 Sep 22 11:46 libcmocka.so -> libcmocka.so.0
lrwxrwxrwx    1 root     root            18 Sep 22 11:49 libcmocka.so.0 -> libcmocka.so.0.3.1
-rwxr-xr-x    1 root     root         53016 Sep 22 11:46 libcmocka.so.0.3.1
-rw-r--r--    1 root     root         49410 Sep 22 11:49 libmsgpackc.a
lrwxrwxrwx    1 root     root            16 Sep 22 11:49 libmsgpackc.so -> libmsgpackc.so.2
lrwxrwxrwx    1 root     root            20 Sep 22 11:49 libmsgpackc.so.2 -> libmsgpackc.so.2.0.0
-rwxr-xr-x    1 root     root         42808 Sep 22 11:49 libmsgpackc.so.2.0.0
-rw-r--r--    1 root     root        785168 Sep 22 11:49 libnopoll.a
-rwxr-xr-x    1 root     root           964 Sep 22 11:49 libnopoll.la
lrwxrwxrwx    1 root     root            18 Sep 22 11:49 libnopoll.so -> libnopoll.so.0.0.0
lrwxrwxrwx    1 root     root            18 Sep 22 11:49 libnopoll.so.0 -> libnopoll.so.0.0.0
-rwxr-xr-x    1 root     root        523712 Sep 22 11:49 libnopoll.so.0.0.0
lrwxrwxrwx    1 root     root            25 Sep 22 11:49 libtrower-base64.so -> libtrower-base64.so.1.0.0
-rwxr-xr-x    1 root     root         13696 Sep 22 11:49 libtrower-base64.so.1.0.0
-rw-r--r--    1 root     root         65632 Sep 22 11:49 libwrp-c.a
-rwxr-xr-x    1 root     root         60168 Sep 22 11:49 libwrp-c.so
drwxr-xr-x    2 root     root          4096 Sep 22 11:49 pkgconfig
/build/parodus/build/_install/lib64
total 1424
drwxr-xr-x    4 root     root          4096 Sep 22 11:49 .
drwxr-xr-x    6 root     root          4096 Sep 22 11:48 ..
drwxr-xr-x    5 root     root          4096 Sep 22 11:49 cmake
lrwxrwxrwx    1 root     root            13 Sep 22 11:48 libcjson.so -> libcjson.so.1
lrwxrwxrwx    1 root     root            17 Sep 22 11:48 libcjson.so.1 -> libcjson.so.1.7.8
-rwxr-xr-x    1 root     root         42856 Sep 22 11:48 libcjson.so.1.7.8
-rwxr-xr-x    1 root     root       1003840 Sep 22 11:47 libcurl.so
lrwxrwxrwx    1 root     root            15 Sep 22 11:49 libnanomsg.so -> libnanomsg.so.5
lrwxrwxrwx    1 root     root            19 Sep 22 11:49 libnanomsg.so.5 -> libnanomsg.so.5.1.0
-rwxr-xr-x    1 root     root        388272 Sep 22 11:49 libnanomsg.so.5.1.0
drwxr-xr-x    2 root     root          4096 Sep 22 11:49 pkgconfig
```

HINT: This PR builds parodus based on `ad2d43b4f6e980a6cc1c1340fc82564104eb1dd8` as the build from parodus/master is broken.